### PR TITLE
Remove hard-coded filename option

### DIFF
--- a/src/cem-plugin.ts
+++ b/src/cem-plugin.ts
@@ -9,7 +9,6 @@ import type { CemSorterOptions } from "./cem-sorter";
  * @returns 
  */
 export function cemSorterPlugin(options: CemSorterOptions = {}) {
-  options.fileName = null;
   return {
     name: "@wc-toolkit/cem-sorter",
     packageLinkPhase({ customElementsManifest }: any) {


### PR DESCRIPTION
This line may have been left over from development; it's overriding the filename so that the new CEM file is never written to disk regardless of the filename option provided in the config.